### PR TITLE
Lisää argument parser

### DIFF
--- a/src/annosennustettavuusmalli/preprocessing/downsamplaus.py
+++ b/src/annosennustettavuusmalli/preprocessing/downsamplaus.py
@@ -13,12 +13,13 @@ import re
 import warnings
 from pathlib import Path
 from typing import List
+
 import numpy as np
 from pydicom import dcmread
 from pydicom.multival import MultiValue
-from scipy.ndimage import zoom 
+from scipy.ndimage import zoom
 
-from annosennustettavuusmalli.preprocessing.luokat import BASE_DIR  
+from annosennustettavuusmalli.preprocessing.luokat import BASE_DIR
 
 
 def ensure_dir(path: str | Path) -> None:
@@ -68,10 +69,25 @@ def find_dicom_by_modality(folder: str, modality: str) -> List[str]:
 
 
 if __name__ == "__main__":
+    from argparse import ArgumentParser
+
+    argparser = ArgumentParser(
+        description="Downsample DICOM files for ANNOSENNUSTETTAVUUSMALLI"
+    )
+    argparser.add_argument(
+        "-d",
+        "--dataset",
+        type=str,
+        required=True,
+        choices=["L", "R", "LAX", "RAX"],
+        help="Valitse datasetti: 'L', 'R', 'LAX', 'RAX'",
+    )
+    args = argparser.parse_args()
+
     print("PROCESSING...")
 
     # Valitse datasetti: "L", "R", "LAX", "RAX"
-    dataset = "L"
+    dataset = args.dataset.upper()
 
     # Mapataan datasetti lähde- ja kohdekansiohin
     if dataset == "L":
@@ -186,7 +202,7 @@ if __name__ == "__main__":
                 mask_down = zoom(mask_orig, zoom=(zoom_y, zoom_x), order=0)
 
                 # Slice-reversointi: käännä index Z-akselilla
-                idx = len(mask_files) - 1 - i  
+                idx = len(mask_files) - 1 - i
                 # Sovitetaan dose tähän sliceen
                 # HUOM! Ei tehdä maskin mukaan multiplicaatiota, vaan indeksi vain järjestää
                 dose_slice = arr_dose_down_flipped[idx, :, :]
@@ -220,9 +236,9 @@ if __name__ == "__main__":
                 except Exception as e:
                     warnings.warn(
                         f"{patient_name}: RD-tiedoston tallennus doseds-kansioon epäonnistui: {e}"
-                    )       
-                    
-            # Kopioidaan RS ja RP muuttumattomina 
+                    )
+
+            # Kopioidaan RS ja RP muuttumattomina
             for f in rp_files:
                 try:
                     ds = dcmread(f, stop_before_pixels=True)

--- a/src/annosennustettavuusmalli/preprocessing/luokat.py
+++ b/src/annosennustettavuusmalli/preprocessing/luokat.py
@@ -7,19 +7,20 @@ Luokkarakenne yhdistämään ja vähentämään toistoa preprocessing koodeissa.
 Alkuperäisille ja muokatuille tiedostoille tehty eri tiedostopolut.
 """
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
-import re
 
 # Keskitetty juuripolku:
 BASE_DIR = Path(r"C:\Users\User01\GRADU\Aineisto")
 
+
 @dataclass
 class Patient:
-    processed_dataset: Path   # esim. "VN0ds", mihin tulokset tallennetaan
-    original_dataset: Path    # esim. "VN0", mistä lähdetiedostot haetaan
-    patient_folder: Path      # esim. Patient1_VN0
-    
+    processed_dataset: Path  # esim. "VN0ds", mihin tulokset tallennetaan
+    original_dataset: Path  # esim. "VN0", mistä lähdetiedostot haetaan
+    patient_folder: Path  # esim. Patient1_VN0
+
     def __post_init__(self):
         self.processed_dataset = Path(self.processed_dataset)
         self.original_dataset = Path(self.original_dataset)
@@ -36,13 +37,12 @@ class Patient:
         """Muokattujen tiedostojen kansio (tulokset)."""
         return BASE_DIR / self.processed_dataset / self.patient_folder
 
-
     # TIEDOSTOJEN POLUT
     # Alkuperäisten CT-kuvien kansio
     @property
     def org_ct_dir(self) -> Path:
         return self.modified_dir / "vanha ct"
-    
+
     # Modifioitujen CT-kuvien kansio
     @property
     def ct_dir(self) -> Path:
@@ -52,7 +52,7 @@ class Patient:
     @property
     def mask_dir(self) -> Path:
         return self.modified_dir / "maski"
-    
+
     # Modifioitujen rakennemaskien kansio
     @property
     def maskds_dir(self) -> Path:
@@ -62,7 +62,7 @@ class Patient:
     @property
     def dose_dir(self) -> Path:
         return self.modified_dir / "dose"
-    
+
     # Modifioidun dose:n kansio
     @property
     def doseds_dir(self) -> Path:
@@ -78,12 +78,12 @@ class Patient:
     def plan_dir(self) -> Path:
         return self.modified_dir / "plan"
 
-
     # NUMERON HAKU JÄRJESTYSTÄ VARTEN
     @property
     def number(self) -> int:
         m = re.search(r"(\d+)", str(self.patient_folder))
         return int(m.group(1)) if m else 0
+
 
 @dataclass
 class AllPatients:
@@ -93,7 +93,7 @@ class AllPatients:
     def __post_init__(self):
         self.processed_dataset = Path(self.processed_dataset)
         self.original_dataset = Path(self.original_dataset)
-        self._patients = self._find_patients()   
+        self._patients = self._find_patients()
 
     def _find_patients(self):
         dataset_path = BASE_DIR / self.processed_dataset
@@ -103,7 +103,7 @@ class AllPatients:
             Patient(
                 processed_dataset=self.processed_dataset,
                 original_dataset=self.original_dataset,
-                patient_folder=p.name
+                patient_folder=p,
             )
             for p in patient_dirs
         ]

--- a/src/annosennustettavuusmalli/utils/init_weights.py
+++ b/src/annosennustettavuusmalli/utils/init_weights.py
@@ -4,10 +4,10 @@ import torch
 Tekijä: Akseli Leino
 """
 
+
 def init_weights_kaiming(m):
-    """Initializes convolutional kernels with kaiming initialization as suggested by Kaiming He et al.
-    """
+    """Initializes convolutional kernels with kaiming initialization as suggested by Kaiming He et al."""
     if isinstance(m, torch.nn.Conv3d):
         torch.nn.init.kaiming_normal_(m.weight)
-        if m.bias != None:
+        if m.bias is not None:
             torch.nn.init.zeros_(m.bias)


### PR DESCRIPTION
Kun lisää tällaisen argument parserin tuohon moduliin niin datasetin voi määrittää komentoriviltä annettavalla argumentilla ilman että itse downsamplaus.py tiedostoa tarvitsisi joka kerta ajokerralla muokata kun haluaa ajaa eri datasetin.

Esimerkiksi komennolla

```bash
python downsamplaus.py -d L
```
saa ajettua datat "VN0". Tämä vaatii että komentorivillä ollaan samassa kansiossa missä downsamplaus.py tiedosto on.